### PR TITLE
Naaseh venishmah fix

### DIFF
--- a/misc/naaseh_venishmah_quick_fix.py
+++ b/misc/naaseh_venishmah_quick_fix.py
@@ -7,8 +7,11 @@ from sefaria.model import *
 
 def fix_nvn():
     nvn_topic_stub = Topic({"slug": "naaseh-venishmah",
-                            "titles": {"lang": "en", "primary": True, "text": "naaseh-venishmah"}})
+                            "titles": [{"lang": "en", "primary": True, "text": "naaseh-venishmah"}]}).save()
     existing_nvn_topic = Topic().load({"slug": "naaseh-venishma"})
+    # Delete broken link which interferes with merge (the Ref is invalid and does not exist)
+    broken_link = RefTopicLink().load({"toTopic": "naaseh-venishmah", "ref": "Ner Mitzvah, The Kingdom of Greece wishes to uproot the bond between Israel and God 11"})
+    broken_link.delete()
     existing_nvn_topic.merge(nvn_topic_stub)
 
 

--- a/misc/naaseh_venishmah_quick_fix.py
+++ b/misc/naaseh_venishmah_quick_fix.py
@@ -1,0 +1,16 @@
+import django
+
+django.setup()
+
+from sefaria.model import *
+
+
+def fix_nvn():
+    nvn_topic_stub = Topic({"slug": "naaseh-venishmah",
+                            "titles": {"lang": "en", "primary": True, "text": "naaseh-venishmah"}})
+    existing_nvn_topic = Topic().load({"slug": "naaseh-venishma"})
+    existing_nvn_topic.merge(nvn_topic_stub)
+
+
+if __name__ == '__main__':
+    fix_nvn()


### PR DESCRIPTION
When working on scripts that rename indices, often the following warning comes up:

```
{"event": "While building topic TOC, encountered non-existant topic slug: naaseh-venishmah", "timestamp": "2022-11-22T11:01:01.299061Z", "logger": "sefaria.model.text", "severity": "warning"}
```

This code merges the `naaseh-venishma` slug with a `naaseh-venishmah` new topic stub to alleviate the error. In the process, it also deletes a bad link which was interfering with a successful merge. 