### PR TITLE
Shift Topic Categories

### DIFF
--- a/sources/Content_Quality/topic_category_fix.py
+++ b/sources/Content_Quality/topic_category_fix.py
@@ -1,0 +1,55 @@
+import django
+
+django.setup()
+
+from sefaria.model import *
+
+import re
+
+urls = [
+    "https://www.sefaria.org.il/topics/festivals?tab=sources",
+    "https://www.sefaria.org/topics/jewish-calendar2?tab=sheets",
+    "https://www.sefaria.org/topics/kaddish-and-kedushah?tab=sources",
+    "https://www.sefaria.org/topics/lifecycle?tab=sheets",
+    "https://www.sefaria.org/topics/losses?tab=sources",
+    "https://www.sefaria.org/topics/united-states-law?tab=sources",
+    "https://www.sefaria.org.il/topics/festivals?tab=sources",
+    "https://www.sefaria.org/topics/moses-prayer?tab=sources",
+    "https://www.sefaria.org/topics/moses-prayer-for-himself?tab=sources",
+    "https://www.sefaria.org.il/topics/praise-of-god?sort=Relevance&tab=sources",
+    "https://www.sefaria.org.il/topics/priestly-blessing?tab=sources"
+]
+
+# Regular expression pattern
+pattern = r"https://www\.sefaria\.org.*?/topics/(.*)\?"
+
+# List to store extracted slugs
+slugs = []
+
+# Extract slugs from URLs
+for url in urls:
+    match = re.search(pattern, url)
+    if match:
+        slugs.append(match.group(1))
+
+# Remove "categories" (i.e. parent links) for the slugs
+for s in slugs:
+    print(s)
+    tls = IntraTopicLinkSet({'fromTopic': s,
+                             'class': 'intraTopic',
+                             'linkType': 'displays-under'})
+    if tls:
+        topic_link = tls[0]
+        topic_link.delete()
+    print()
+
+# Switch Sefirot from being under both "Beliefs" and "Kabbalah"
+# to just "Kaballah".
+tls = IntraTopicLinkSet({'fromTopic': 'sefirot',
+                         'class': 'intraTopic',
+                         'linkType': 'displays-under',
+                         'toTopic': 'beliefs'})
+
+if tls:
+    topic_link=tls[0]
+    topic_link.delete()

--- a/sources/Content_Quality/topic_category_fix.py
+++ b/sources/Content_Quality/topic_category_fix.py
@@ -22,9 +22,10 @@ def remove_parent_topic_category(from_topic_slug, to_topic_slug=None):
         # Add specific parent if specified
         query['toTopic'] = to_topic_slug
 
-    tls = IntraTopicLinkSet()
+    tls = IntraTopicLinkSet(query)
     if tls:
         topic_link = tls[0]
+        print(topic_link)
         topic_link.delete()
         print(f"Deleting category for {from_topic_slug}")
 

--- a/sources/Content_Quality/topic_category_fix.py
+++ b/sources/Content_Quality/topic_category_fix.py
@@ -12,27 +12,21 @@ from sefaria.model import *
 # and a linkType of dependent indicates that x is under parent y.
 # To remove x from y "category", we simply remove the link between the two.
 
-def remove_parent_topic_category(slug):
+def remove_parent_topic_category(from_topic_slug, to_topic_slug=None):
     # Remove "categories" (i.e. parent links) for the slugs
-    tls = IntraTopicLinkSet({'fromTopic': slug,
-                             'class': 'intraTopic',
-                             'linkType': 'displays-under'})
+    query = {'fromTopic': from_topic_slug,
+             'class': 'intraTopic',
+             'linkType': 'displays-under'}
+
+    if to_topic_slug:
+        # Add specific parent if specified
+        query['toTopic'] = to_topic_slug
+
+    tls = IntraTopicLinkSet()
     if tls:
         topic_link = tls[0]
         topic_link.delete()
-        print(f"Deleting category for {slug}")
-
-
-def specific_topic_cat_adjust(from_topic_slug, to_topic_slug):
-    # Remove Sefirot from being under "beliefs" (but not any other parents)
-    tls = IntraTopicLinkSet({'fromTopic': from_topic_slug,
-                             'class': 'intraTopic',
-                             'linkType': 'displays-under',
-                             'toTopic': to_topic_slug})
-
-    if tls:
-        topic_link = tls[0]
-        topic_link.delete()
+        print(f"Deleting category for {from_topic_slug}")
 
 
 if __name__ == '__main__':
@@ -51,8 +45,11 @@ if __name__ == '__main__':
         "priestly-blessing"
     ]
 
+    # Remove all parents for these slugs
     for s in slugs:
-        remove_parent_topic_category(slug=s)
+        remove_parent_topic_category(from_topic_slug=s)
 
-    specific_topic_cat_adjust(from_topic_slug='sefirot',
-                              to_topic_slug='beliefs')
+    # Specifically remove Sefirot from Beliefs, and no other
+    # parent categories (i.e. "Kabbalah").
+    remove_parent_topic_category(from_topic_slug='sefirot',
+                                 to_topic_slug='beliefs')


### PR DESCRIPTION
This script shifts the parent categories for a list of topic slugs. 

The function has two uses:
1. Removes any parent categories for a given slug (i.e. when `from_topic_slug` is passed a slug, but `to_topic_slug` defaults to `None`). 
2. Removes a specific parent category by specifying both the `from_topic_slug` and the `to_topic_slug` (i.e. remove `Sefirot` from under `Beliefs`, but keep its other parents (i.e. `Kabbalah`).

Categories on topics are inferred from topicLink data. A link `fromTopic` x `toTopic` y that has a `class` of `intra-topic` and a `linkType` of `depends-on` would categorize topic x under category y. Because of this, deleting categories is technically speaking really deleting links, as opposed to `Categories` as they appear as objects relating to indices. 

