### PR TITLE
Update to commentary status

### DIFF
--- a/sources/Content_Quality/sacks_commentary_update.py
+++ b/sources/Content_Quality/sacks_commentary_update.py
@@ -1,0 +1,29 @@
+import django
+
+django.setup()
+
+from sefaria.model import *
+
+index_titles = [
+    "Covenant and Conversation; Genesis; The Book of the Beginnings",
+    "Covenant and Conversation; Exodus; The Book of Redemption",
+    "Covenant and Conversation; Leviticus; The Book of Holiness",
+    "Covenant and Conversation; Numbers; The Wilderness Years",
+    "Covenant and Conversation; Deuteronomy; Renewal of the Sinai Covenant",
+    "Essays in Ethics; A Weekly Reading of the Jewish Bible",
+    "I Believe; A Weekly Reading of the Jewish Bible",
+    "Judaism's Life Changing Ideas; A Weekly Reading of the Jewish Bible",
+    "Lessons in Leadership; a weekly reading of the Jewish Bible",
+    "Studies in Spirituality; A Weekly Reading of the Jewish Bible"
+]
+
+for idx_title in index_titles:
+    print(idx_title)
+    index_object = Index().load({'title': idx_title})
+    print(index_object)
+    index_object.dependence = "Commentary"
+    if "Covenant and Conversation" in idx_title:
+        index_object.collective_title = "Covenant and Conversation"
+    index_object.save()
+
+

--- a/sources/Content_Quality/sacks_commentary_update.py
+++ b/sources/Content_Quality/sacks_commentary_update.py
@@ -20,10 +20,14 @@ index_titles = [
 for idx_title in index_titles:
     print(idx_title)
     index_object = Index().load({'title': idx_title})
-    print(index_object)
+
+    # Assign commentary status
     index_object.dependence = "Commentary"
+
+    # Assign a collective title for the Covenant and Conversation indices
     if "Covenant and Conversation" in idx_title:
         index_object.collective_title = "Covenant and Conversation"
+        
     index_object.save()
 
 


### PR DESCRIPTION
This small script updates the status of each of the provided indices to `commentary`, and assigns a collective title to the indices which are each volumes of the same commentary on different books of Torah. 