### PR TITLE
Script for Bavli Chapter Renames 

### DIFF
--- a/sources/alt_chapter_talmud_rename/alt_toc_repopulate.py
+++ b/sources/alt_chapter_talmud_rename/alt_toc_repopulate.py
@@ -1,0 +1,96 @@
+import django
+import csv
+import time
+
+django.setup()
+
+from sefaria.model import *
+
+
+def retrieve_new_chapter_names():
+    data = {}
+    with open("perek_names - final.csv", newline="", encoding="utf-8") as csvfile:
+        reader = csv.DictReader(csvfile)
+        for row in reader:
+            key = f"{row['Masekhet']} {row['#']}"
+            data[key] = row['English']
+    return data
+
+def retrieve_babylonian_talmud_masechtot():
+    title_list = library.get_indexes_in_category("Talmud")
+    babylonian_talmud_title_list = []
+    for title in title_list:
+        exclusions = ["Tractate", "Jerusalem", "Ahevukha", "DeRabbi", "Introduction"]
+        if all(term not in title for term in exclusions):
+            babylonian_talmud_title_list.append(title)
+    return babylonian_talmud_title_list
+
+
+def name_changer(masechet_index, new_names_data):
+    chap_num = 0
+    for node in masechet_index.alt_structs['Chapters']['nodes']:
+
+        chap_num += 1
+
+        new_title = new_names_data[f"{masechet} {chap_num}"]
+
+        print(f">> Updating {masechet} {chap_num} to {new_title}")
+
+        chapter_title_list = node["titles"]
+        for title in chapter_title_list:
+            if title['lang'] == 'en':
+                title['text'] = new_title
+
+    masechet_index.save()
+
+def test_title_changed(new_names_data, masechet):
+    masechet_index = Ref(masechet).index
+
+    chap_num = 0
+    for node in masechet_index.alt_structs['Chapters']['nodes']:
+
+        chap_num += 1
+
+        new_title = new_names_data[f"{masechet} {chap_num}"]
+
+        chapter_title_list = node["titles"]
+        for title in chapter_title_list:
+            if title['lang'] == 'en':
+                assert title['text'] == new_title
+
+
+def test_all_titles_changed():
+    new_names_data = retrieve_new_chapter_names()
+    masechtot = retrieve_babylonian_talmud_masechtot()
+    for masechet in masechtot:
+        test_title_changed(new_names_data, masechet)
+
+def test_bava_kamma_hebrew():
+    bk_index = Ref("Bava Kamma 2").index
+    assert bk_index.alt_structs["Chapters"]["nodes"][1]["titles"][1]["text"] == "כיצד הרגל"
+
+
+if __name__ == '__main__':
+
+    start = time.time()
+
+    # Ingest CSV
+    new_names_data = retrieve_new_chapter_names()
+
+    # Retrieve all masechtot
+    masechtot = retrieve_babylonian_talmud_masechtot()
+
+    # Run the name-changer on a masechet-by-masechet basis
+    for masechet in masechtot:
+       masechet_index = Ref(masechet).index
+       print(masechet_index)
+       name_changer(masechet_index, new_names_data)
+
+    end = time.time()
+
+    print(f"Total run time {end-start}")
+
+    # Hebrew fix
+    bk_index = Ref("Bava Kamma 2").index
+    bk_index.alt_structs["Chapters"]["nodes"][1]["titles"][1]["text"] = "כיצד הרגל"
+    bk_index.save()

--- a/sources/alt_chapter_talmud_rename/perek_names - final.csv
+++ b/sources/alt_chapter_talmud_rename/perek_names - final.csv
@@ -1,0 +1,314 @@
+Masekhet,#,Hebrew,English
+Horayot,1,הורו בית דין,Chapter 1; Horu Beit Din
+Horayot,2,הורה כהן משיח,Chapter 2; Horah Kohen Mashiach
+Horayot,3,כהן משיח,Chapter 3; Kohen Mashiach
+Avodah Zarah,1,לפני אידיהן,Chapter 1; Lifnei Eideihen
+Avodah Zarah,2,אין מעמידין,Chapter 2; Ein Ma'amidin
+Avodah Zarah,3,כל הצלמים,Chapter 3; Kol HaTzelamim
+Avodah Zarah,4,רבי ישמעאל,Chapter 4; Rabbi Yishmael
+Avodah Zarah,5,השוכר את הפועל,Chapter 5; HaSokher et HaPoel
+Megillah,1,מגילה נקראת,Chapter 1; Megillah Nikreit
+Megillah,2,הקורא למפרע,Chapter 2; HaKorei Lemafrea
+Megillah,3,הקורא עומד,Chapter 3; HaKorei Omed
+Megillah,4,בני העיר,Chapter 4; Benei HaIr
+Shevuot,1,שבועות שתים קמא,Chapter 1; Shevuot Shetayim Kamma
+Shevuot,2,ידיעות הטומאה,Chapter 2; Yediot HaTumah
+Shevuot,3,שבועות שתים בתרא,Chapter 3; Shevuot Shetayim Batra
+Shevuot,4,שבועת העדות,Chapter 4; Shevuat HaEdut
+Shevuot,5,שבועת הפקדון,Chapter 5; Shevuat HaPikkadon
+Shevuot,6,שבועת הדיינין,Chapter 6; Shevuat HaDayyanin
+Shevuot,7,כל הנשבעין,Chapter 7; Kol HaNishbain
+Shevuot,8,ארבעה שומרין,Chapter 8; Arba'ah Shomrim
+Berakhot,1,מאימתי,Chapter 1; MeEimatai
+Berakhot,2,היה קורא,Chapter 2; Hayah Korei
+Berakhot,3,מי שמתו,Chapter 3; Mi SheMetu
+Berakhot,4,תפלת השחר,Chapter 4; Tefillat HaShachar
+Berakhot,5,אין עומדין,Chapter 5; Ein Omdin
+Berakhot,6,כיצד מברכין,Chapter 6; Keitzad Mevarchin
+Berakhot,7,שלשה שאכלו,Chapter 7; Sheloshah SheAchlu
+Berakhot,8,אלו דברים,Chapter 8; Ellu Devarim
+Berakhot,9,הרואה,Chapter 9; HaRoeh
+Bekhorot,1,הלוקח עובר חמורו,Chapter 1; HaLokeach Ubbar Chamoro
+Bekhorot,2,הלוקח עובר פרתו,Chapter 2; HaLokeach Ubbar Parato
+Bekhorot,3,הלוקח בהמה,Chapter 3; HaLokeach Behemah
+Bekhorot,4,עד כמה,Chapter 4; Ad Kammah
+Bekhorot,5,כל פסולי המוקדשין,Chapter 5; Kol Pesulei HaMukdashin
+Bekhorot,6,על אלו מומין,Chapter 6; Al Ellu Mumin
+Bekhorot,7,מומין אלו,Chapter 7; Mumin Ellu
+Bekhorot,8,יש בכור,Chapter 8; Yesh Bekhor
+Bekhorot,9,מעשר בהמה,Chapter 9; Ma'aser Behemah
+Sanhedrin,1,דיני ממונות,Chapter 1; Dinei Mamonot
+Sanhedrin,2,כהן גדול,Chapter 2; Kohen Gadol
+Sanhedrin,3,זה בורר,Chapter 3; Zeh Borer
+Sanhedrin,4,אחד דיני ממונות,Chapter 4; Echad Dinei Mamonot
+Sanhedrin,5,היו בודקין,Chapter 5; Hayu Bodkin
+Sanhedrin,6,נגמר הדין,Chapter 6; Nigmar HaDin
+Sanhedrin,7,ארבע מיתות,Chapter 7; Arba Mitot
+Sanhedrin,8,בן סורר ומורה,Chapter 8; Ben Sorer Umoreh
+Sanhedrin,9,הנשרפין,Chapter 9; HaNisrafin
+Sanhedrin,10,אלו הן הנחנקין,Chapter 10; Ellu Hen HaNechnakin
+Sanhedrin,11,חלק,Chapter 11; Chelek
+Nazir,1,כל כנויי נזירות,Chapter 1; Kol Kinnuyei Nezirut
+Nazir,2,הריני נזיר,Chapter 2; Hareini Nazir
+Nazir,3,מי שאמר קמא,Chapter 3; Mi SheAmar Kamma
+Nazir,4,מי שאמר בתרא,Chapter 4; Mi SheAmar Batra
+Nazir,5,בית שמאי,Chapter 5; Beit Shammai
+Nazir,6,שלשה מינין,Chapter 6; Sheloshah Minin
+Nazir,7,כהן גדול,Chapter 7; Kohen Gadol
+Nazir,8,שני נזירים,Chapter 8; Shenei Nezirim
+Nazir,9,הכותים אין להם נזירות,Chapter 9; HaKutim Ein Lahem Nezirut
+Bava Kamma,1,ארבעה אבות,Chapter 1; Arba'ah Avot
+Bava Kamma,2,כיצד רגל,Chapter 2; Keitzad HaRegel
+Bava Kamma,3,המניח,Chapter 3; HaManiach
+Bava Kamma,4,שור שנגח ד' וה',Chapter 4; Shor SheNagach Arba'ah VaChamishah
+Bava Kamma,5,שור שנגח את הפרה,Chapter 5; Shor SheNagach et HaParah
+Bava Kamma,6,הכונס,Chapter 6; HaKones
+Bava Kamma,7,מרובה,Chapter 7; Merubbeh
+Bava Kamma,8,החובל,Chapter 8; HaChovel
+Bava Kamma,9,הגוזל עצים,Chapter 9; HaGozel Etzim
+Bava Kamma,10,הגוזל בתרא,Chapter 10; HaGozel Batra
+Sotah,1,המקנא,Chapter 1; HaMekannei
+Sotah,2,היה מביא,Chapter 2; Hayah Mevi 
+Sotah,3,היה נוטל,Chapter 3; Hayah Notel
+Sotah,4,ארוסה,Chapter 4; Arusah
+Sotah,5,כשם שהמים,Chapter 5; KeShem SheHamayim
+Sotah,6,מי שקינא,Chapter 6; Mi SheKinnei
+Sotah,7,אלו נאמרין,Chapter 7; Ellu Ne'emarin
+Sotah,8,משוח מלחמה,Chapter 8; Mashuach Milchamah
+Sotah,9,עגלה ערופה,Chapter 9; Eglah Arufah
+Bava Batra,1,השותפין,Chapter 1; HaShuttafin
+Bava Batra,2,לא יחפור,Chapter 2; Lo Yachpor
+Bava Batra,3,חזקת הבתים,Chapter 3; Chezkat HaBattim
+Bava Batra,4,המוכר את הבית,Chapter 4; HaMokher et HaBayit
+Bava Batra,5,המוכר את הספינה,Chapter 5; HaMokher et HaSefinah
+Bava Batra,6,המוכר פירות,Chapter 6; HaMokher Peirot
+Bava Batra,7,בית כור,Chapter 7; Beit Kur
+Bava Batra,8,יש נוחלין,Chapter 8; Yesh Nochalin
+Bava Batra,9,מי שמת,Chapter 9; Mi SheMet
+Bava Batra,10,גט פשוט,Chapter 10; Get Pashut
+Yoma,1,שבעת ימים,Chapter 1; Shivat Yamim
+Yoma,2,בראשונה,Chapter 2; BaRishonah
+Yoma,3,אמר להם הממונה,Chapter 3; Amar Lahem HaMemunneh
+Yoma,4,טרף בקלפי,Chapter 4; Taraf BaKalpi
+Yoma,5,הוציאו לו,Chapter 5; Hotziu Lo
+Yoma,6,שני שעירי,Chapter 6; Shenei Seirei
+Yoma,7,בא לו,Chapter 7; Ba Lo
+Yoma,8,יום הכפורים,Chapter 8; Yom HaKippurim
+Meilah,1,קדשי קדשים,Chapter 1; Kodshei Kodashim
+Meilah,2,חטאת העוף,Chapter 2; Chatat HaOf
+Meilah,3,ולד חטאת,Chapter 3; Velad Chatat
+Meilah,4,קדשי מזבח,Chapter 4; Kodshei Mizbeach
+Meilah,5,הנהנה מן ההקדש,Chapter 5; HaNeheneh Min HaHekdesh
+Meilah,6,השליח שעשה שליחותו,Chapter 6; HaShaliach SheAsah Shelichuto
+Keritot,1,שלשים ושש,Chapter 1; Sheloshim VeShesh
+Keritot,2,ארבעה מחוסרי כפרה,Chapter 2; Arba'ah Mechusrei Kapparah
+Keritot,3,אמרו לו,Chapter 3; Amru Lo
+Keritot,4,ספק אכל חלב,Chapter 4; Safek Akhal Chelev
+Keritot,5,דם שחיטה,Chapter 5; Dam Shechitah
+Keritot,6,המביא אשם,Chapter 6; HaMevi Asham
+Tamid,1,בשלשה מקומות,Chapter 1; BiShloshah Mekomot 
+Tamid,2,ראוהו אחיו,Chapter 2; Rauhu Echav
+Tamid,3,אמר להם הממונה בואו,Chapter 3; Amar Lahem HaMemunneh Bou
+Tamid,4,לא היו כופתין,Chapter 4; Lo Hayu Koftin
+Tamid,5,אמר להם הממונה ברכו,Chapter 5; Amar Lahem HaMemunneh Barkhu
+Tamid,6,החלו עולים,Chapter 6; Hechellu Olim
+Tamid,7,בזמן שכהן גדול,Chapter 7; BiZman SheKohen Gadol
+Arakhin,1,הכל מעריכין,Chapter 1; HaKol Ma'arikhin
+Arakhin,2,אין נערכין,Chapter 2; Ein Ne'erakhin
+Arakhin,3,יש בערכין,Chapter 3; Yesh BaArakhin
+Arakhin,4,השג יד,Chapter 4; Hesseg Yad
+Arakhin,5,האומר משקלי עלי,Chapter 5; HaOmer Mishkali Alai
+Arakhin,6,שום היתומים,Chapter 6; Shum HaYetomim
+Arakhin,7,אין מקדישין,Chapter 7; Ein Makdishin
+Arakhin,8,המקדיש שדהו,Chapter 8; HaMakdish Sadehu
+Arakhin,9,המוכר שדהו,Chapter 9; HaMokher Sadehu
+Niddah,1,שמאי אומר,Chapter 1; Shammai Omer
+Niddah,2,כל היד,Chapter 2; Kol HaYad
+Niddah,3,המפלת חתיכה,Chapter 3; HaMappelet Chatikhah
+Niddah,4,בנות כותים,Chapter 4; Benot Kutim
+Niddah,5,יוצא דופן,Chapter 5; Yotze Dofen
+Niddah,6,בא סימן,Chapter 6; Ba Siman
+Niddah,7,דם הנדה,Chapter 7; Dam HaNiddah
+Niddah,8,הרואה כתם,Chapter 8; HaRoeh Ketem
+Niddah,9,האשה שהיא עושה,Chapter 9; HaIshah SheHi Osah
+Niddah,10,תינוקת,Chapter 10; Tinoket
+Gittin,1,המביא קמא,Chapter 1; HaMevi Kamma
+Gittin,2,המביא בתרא,Chapter 2; HaMevi Batra
+Gittin,3,כל הגט,Chapter 3; Kol HaGet
+Gittin,4,השולח,Chapter 4; HaSholeach
+Gittin,5,הניזקין,Chapter 5; HaNizzakin
+Gittin,6,האומר התקבל,Chapter 6; HaOmer Hitkabbel
+Gittin,7,מי שאחזו,Chapter 7; Mi SheAchazo
+Gittin,8,הזורק גט,Chapter 8; HaZorek Get
+Gittin,9,המגרש,Chapter 9; HaMegaresh
+Yevamot,1,חמש עשרה נשים,Chapter 1; Chamesh Esreh Nashim
+Yevamot,2,כיצד אשת אחיו,Chapter 2; Keitzad Eshet Achiv
+Yevamot,3,ארבעה אחין,Chapter 3; Arba'ah Achin
+Yevamot,4,החולץ,Chapter 4; HaCholetz
+Yevamot,5,רבן גמליאל,Chapter 5; Rabban Gamliel
+Yevamot,6,הבא על יבמתו,Chapter 6; HaBa Al Yevimto
+Yevamot,7,אלמנה לכהן גדול,Chapter 7; Almanah LeKohen Gadol 
+Yevamot,8,הערל,Chapter 8; HaArel
+Yevamot,9,יש מותרות,Chapter 9; Yesh Muttarot
+Yevamot,10,האישה רבה,Chapter 10; HaIshah Rabbah
+Yevamot,11,נושאין על האנוסה,Chapter 11; Nosin Al HaAnusah
+Yevamot,12,מצות חליצה,Chapter 12; Mitzvat Chalitzah
+Yevamot,13,בית שמאי,Chapter 13; Beit Shammai
+Yevamot,14,חרש שנשא,Chapter 14; Cheresh SheNasa
+Yevamot,15,האשה שלום,Chapter 15; HaIshah Shalom
+Yevamot,16,האשה בתרא,Chapter 16; HaIshah Batra
+Moed Katan,1,משקין בית השלחין,Chapter 1; Mashkin Beit HaShelachin
+Moed Katan,2,מי שהפך,Chapter 2; Mi SheHafakh
+Moed Katan,3,ואלו מגלחין,Chapter 3; VeEllu Megallechin
+Chagigah,1,הכל חייבין,Chapter 1; HaKol Chayyavin
+Chagigah,2,אין דורשין,Chapter 2; Ein Dorshin
+Chagigah,3,חומר בקודש,Chapter 3; Chomer BaKodesh
+Shabbat,1,יציאות השבת,Chapter 1; Yetziot HaShabbat
+Shabbat,2,במה מדליקין,Chapter 2; BaMeh Madlikin
+Shabbat,3,כירה,Chapter 3; Kirah
+Shabbat,4,במה טומנין,Chapter 4; BaMeh Tomnin
+Shabbat,5,במה בהמה,Chapter 5; BaMeh Behemah
+Shabbat,6,במה אשה,Chapter 6; BaMeh Ishah
+Shabbat,7,כלל גדול,Chapter 7; Kelal Gadol
+Shabbat,8,המוציא יין,Chapter 8; HaMotzi Yayin
+Shabbat,9,אמר רבי עקיבא,Chapter 9; Amar Rabbi Akiva
+Shabbat,10,המצניע,Chapter 10; HaMatznia
+Shabbat,11,הזורק,Chapter 11; HaZorek
+Shabbat,12,הבונה,Chapter 12; HaBoneh
+Shabbat,13,האורג,Chapter 13; HaOreg
+Shabbat,14,שמנה שרצים,Chapter 14; Shemoneh Sheratzim
+Shabbat,15,ואלו קשרים,Chapter 15; VeEllu Kesharim
+Shabbat,16,כל כתבי,Chapter 16; Kol Kitvei
+Shabbat,17,כל הכלים,Chapter 17; Kol HaKelim
+Shabbat,18,מפנין,Chapter 18; Mefannin
+Shabbat,19,רבי אליעזר דמילה,Chapter 19; Rabbi Eliezer DeMilah
+Shabbat,20,תולין,Chapter 20; Tolin
+Shabbat,21,נוטל אדם את בנו,Chapter 21; Notel Adam et Beno
+Shabbat,22,חבית,Chapter 22; Chavit
+Shabbat,23,שואל,Chapter 23; Shoel
+Shabbat,24,מי שהחשיך,Chapter 24; Mi SheHechshikh
+Eruvin,1,מבוי,Chapter 1; Mavoi
+Eruvin,2,עושין פסין,Chapter 2; Osin Passin
+Eruvin,3,בכל מערבין,Chapter 3; BaKol Mearvin
+Eruvin,4,מי שהוציאוהו,Chapter 4; Mi SheHotziuhu
+Eruvin,5,כיצד,Chapter 5; Keitzad
+Eruvin,6,הדר,Chapter 6; HaDar
+Eruvin,7,חלון,Chapter 7; Challon
+Eruvin,8,כיצד משתתפין,Chapter 8; Keitzad Mishtattfin
+Eruvin,9,כל גגות,Chapter 9; Kol Gaggot
+Eruvin,10,המוצא תפילין,Chapter 10; HaMotzei Tefillin
+Bava Metzia,1,שנים אוחזין,Chapter 1; Shenayim Ochazin
+Bava Metzia,2,אלו מציאות,Chapter 2; Ellu Metziot
+Bava Metzia,3,המפקיד,Chapter 3; HaMafkid
+Bava Metzia,4,הזהב,Chapter 4; HaZahav
+Bava Metzia,5,איזהו נשך,Chapter 5; Eizehu Neshekh
+Bava Metzia,6,השוכר את האומנין,Chapter 6; HaSokher et HaUmmanin
+Bava Metzia,7,השוכר את הפועלים,Chapter 7; HaSokher et HaPoalim
+Bava Metzia,8,השואל את הפרה,Chapter 8; HaShoel et HaParah
+Bava Metzia,9,המקבל שדה מחבירו,Chapter 9; HaMekabbel Sadeh MeChavero
+Bava Metzia,10,הבית והעלייה,Chapter 10; HaBayit VeHa'aliyyah
+Zevachim,1,כל הזבחים,Chapter 1; Kol HaZevachim
+Zevachim,2,כל הזבחים שקבלו דמן,Chapter 2; Kol HaZevachim SheKibblu Daman
+Zevachim,3,כל הפסולין,Chapter 3; Kol HaPesulin
+Zevachim,4,בית שמאי,Chapter 4; Beit Shammai
+Zevachim,5,איזהו מקומן,Chapter 5; Eizehu Mekoman
+Zevachim,6,קדשי קדשים,Chapter 6; Kodshei Kodashim
+Zevachim,7,חטאת העוף,Chapter 7; Chatat HaOf
+Zevachim,8,כל הזבחים שנתערבו,Chapter 8; Kol HaZevachim SheNitarvu
+Zevachim,9,המזבח מקדש,Chapter 9; HaMizbeach Mekaddesh
+Zevachim,10,כל התדיר,Chapter 10; Kol HaTadir
+Zevachim,11,דם חטאת,Chapter 11; Dam Chatat
+Zevachim,12,טבול יום,Chapter 12; Tevul Yom
+Zevachim,13,השוחט והמעלה,Chapter 13; HaShochet VeHama'aleh
+Zevachim,14,פרת חטאת,Chapter 14; Parat Chatat
+Kiddushin,1,האשה נקנית,Chapter 1; HaIshah Nikneit
+Kiddushin,2,האיש מקדש,Chapter 2; HaIsh Mekaddesh
+Kiddushin,3,האומר לחברו,Chapter 3; HaOmer LeChavero
+Kiddushin,4,עשרה יוחסין,Chapter 4; Asarah Yochasin
+Chullin,1,הכל שוחטין,Chapter 1; HaKol Shochatin
+Chullin,2,השוחט,Chapter 2; HaShochet
+Chullin,3,אלו טרפות,Chapter 3; Ellu Terefot
+Chullin,4,בהמה,Chapter 4; Behemah
+Chullin,5,אותו ואת בנו,Chapter 5; Oto VeEt Beno
+Chullin,6,כסוי הדם,Chapter 6; Kissui HaDam
+Chullin,7,גיד הנשה,Chapter 7; Gid HaNasheh
+Chullin,8,כל הבשר,Chapter 8; Kol HaBasar
+Chullin,9,העור והרוטב,Chapter 9; HaOr VeHarotev
+Chullin,10,הזרוע והלחיים,Chapter 10; HaZeroa VeHalechayim
+Chullin,11,ראשית הגז,Chapter 11; Reshit HaGez
+Chullin,12,שילוח הקן,Chapter 12; Shilluach HaKen
+Temurah,1,הכל ממירין,Chapter 1; HaKol Memirin
+Temurah,2,יש בקרבנות,Chapter 2; Yesh BeKorbenot
+Temurah,3,אלו קדשים,Chapter 3; Ellu Kadashim
+Temurah,4,ולד חטאת,Chapter 4; Velad Chatat
+Temurah,5,כיצד מערימין,Chapter 5; Keitzad Ma'arimin
+Temurah,6,כל האסורין,Chapter 6; Kol HaAsurin
+Temurah,7,יש בקדשי מזבח,Chapter 7; Yesh BeKodshei Mizbeach
+Taanit,1,מאימתי מזכירין,Chapter 1; MeEimatai Mazkirin
+Taanit,2,סדר תעניות,Chapter 2; Seder Ta'anit
+Taanit,3,סדר תעניות אלו,Chapter 3; Seder Ta'aniyot Elu
+Taanit,4,בשלשה פרקים,Chapter 4; BiShloshah Perakim
+Beitzah,1,ביצה,Chapter 1; Beitzah
+Beitzah,2,יום טוב,Chapter 2; Yom Tov
+Beitzah,3,אין צדין,Chapter 3; Ein Tzadin
+Beitzah,4,המביא כדי יין,Chapter 4; HaMevi Kaddei Yayin
+Beitzah,5,משילין,Chapter 5; Mashilin
+Rosh Hashanah,1,ארבעה ראשי שנים,Chapter 1; Arba'ah Rashei Shanim
+Rosh Hashanah,2,אם אינן מכירין,Chapter 2; Im Einan Makkirin
+Rosh Hashanah,3,ראוהו בית דין,Chapter 3; Rauhu Beit Din
+Rosh Hashanah,4,יום טוב,Chapter 4; Yom Tov
+Nedarim,1,כל כנויי,Chapter 1; Kol Kinnuyei
+Nedarim,2,ואלו מותרין,Chapter 2; VeEllu Muttarin
+Nedarim,3,ארבעה נדרים,Chapter 3; Arba'ah Nedarim
+Nedarim,4,אין בין המודר,Chapter 4; Ein Bein HaMuddar
+Nedarim,5,השותפין שנדרו,Chapter 5; HaShuttafin SheNadru
+Nedarim,6,הנודר מן המבושל,Chapter 6; HaNoder Min HaMevushal
+Nedarim,7,הנודר מן הירק,Chapter 7; HaNoder Min HaYarak
+Nedarim,8,קונם יין,Chapter 8; Konam Yayin
+Nedarim,9,רבי אליעזר,Chapter 9; Rabbi Eliezer
+Nedarim,10,נערה המאורסה,Chapter 10; Na'arah HaMeorasah
+Nedarim,11,ואלו נדרים,Chapter 11; VeEllu Nedarim
+Menachot,1,כל המנחות,Chapter 1; Kol HaMenachot
+Menachot,2,הקומץ את המנחה,Chapter 2; HaKometz et HaMinchah
+Menachot,3,הקומץ רבה,Chapter 3; HaKometz Rabbah
+Menachot,4,התכלת,Chapter 4; HaTekhelet
+Menachot,5,כל המנחות באות מצה,Chapter 5; Kol HaMenachot Baot Matzah
+Menachot,6,רבי ישמעאל,Chapter 6; Rabbi Yishmael
+Menachot,7,אלו מנחות נקמצות,Chapter 7; Ellu Menachot Nikmatzot
+Menachot,8,התודה היתה באה,Chapter 8; HaTodah Haytah Ba'ah
+Menachot,9,כל קרבנות ציבור,Chapter 9; Kol Korbanot Tzibbur
+Menachot,10,שתי מדות,Chapter 10; Shetei Middot
+Menachot,11,שתי הלחם,Chapter 11; Shetei HaLechem
+Menachot,12,המנחות והנסכים,Chapter 12; HaMenachot VeHanesakhim
+Menachot,13,הרי עלי עשרון,Chapter 13; Harei Alai Issaron
+Pesachim,1,אור לארבעה עשר,Chapter 1; Or LeArba'ah Asar
+Pesachim,2,כל שעה,Chapter 2; Kol Sha'ah
+Pesachim,3,אלו עוברין,Chapter 3; Ellu Ovrim
+Pesachim,4,מקום שנהגו,Chapter 4; Makom SheNahagu
+Pesachim,5,תמיד נשחט,Chapter 5; Tamid Nishchat
+Pesachim,6,אלו דברים,Chapter 6; Ellu Devarim
+Pesachim,7,כיצד צולין,Chapter 7; Keitzad Tzolin
+Pesachim,8,האשה,Chapter 8; HaIshah
+Pesachim,9,מי שהיה טמא,Chapter 9; Mi SheHayah Tamei
+Pesachim,10,ערבי פסחים,Chapter 10; Arvei Pesachim
+Ketubot,1,בתולה נשאת,Chapter 1; Betulah Nisset
+Ketubot,2,האשה שנתארמלה,Chapter 2; HaIshah SheNitarmelah
+Ketubot,3,אלו נערות,Chapter 3; Ellu Na'arot
+Ketubot,4,נערה שנתפתתה,Chapter 4; Na'arah SheNitpattetah
+Ketubot,5,אף על פי,Chapter 5; Af Al Pi
+Ketubot,6,מציאת האשה,Chapter 6; Metziat HaIshah
+Ketubot,7,המדיר,Chapter 7; HaMaddir
+Ketubot,8,האשה שנפלו,Chapter 8; HaIshah SheNaflu
+Ketubot,9,הכותב לאשתו,Chapter 9; HaKotev LeIshto
+Ketubot,10,מי שהיה נשוי,Chapter 10; Mi SheHayah Nasui
+Ketubot,11,אלמנה ניזונת,Chapter 11; Almanah Nizzonet
+Ketubot,12,הנושא את האשה,Chapter 12; HaNosei et HaIshah
+Ketubot,13,שני דייני גזירות,Chapter 13; Shenei Dayyanei Gezeirot
+Sukkah,1,סוכה,Chapter 1; Sukkah
+Sukkah,2,הישן,Chapter 2; HaYashen
+Sukkah,3,לולב הגזול,Chapter 3; Lulav HaGazul
+Sukkah,4,לולב וערבה,Chapter 4; Lulav VeAravah
+Sukkah,5,החליל,Chapter 5; HeChalil
+Makkot,1,כיצד העדים,Chapter 1; Keitzad HaEdim
+Makkot,2,אלו הן הגולין,Chapter 2; Ellu Hen HaGolin
+Makkot,3,אלו הן הלוקין,Chapter 3; Ellu Hen HaLokin


### PR DESCRIPTION
Script to rename the Bavli Chapters (English) with their transliterated names, as well as one correction for the Hebrew name of Bava Kamma 2. 